### PR TITLE
Generated code cleanup + Optional field setters

### DIFF
--- a/static/prelude.rs
+++ b/static/prelude.rs
@@ -2,10 +2,6 @@ use cbor_event::{self, de::{Deserialize, Deserializer}, se::{Serialize, Serializ
 use std::io::Write;
 use wasm_bindgen::prelude::*;
 
-// TODO: handle this by not passing throught be barrior directly.
-//       instead have it either:
-//  1) generate 1 per each wrapped type
-//  2) don't pass it, instead wrap it/unwrap it automatically
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct TaggedData<T> {
     pub (crate) data: T,

--- a/supported.cddl
+++ b/supported.cddl
@@ -22,15 +22,15 @@ kes_signature = bytes
 
 pointer = (uint, uint, uint)
 address =
- (  0, keyhash, keyhash       ; base address
- // 1, keyhash, scripthash    ; base address
- // 2, scripthash, keyhash    ; base address
- // 3, scripthash, scripthash ; base address
- // 4, keyhash, pointer       ; pointer address
- // 5, scripthash, pointer    ; pointer address
- // 6, keyhash                ; enterprise address (null staking reference)
- // 7, scripthash             ; enterprise address (null staking reference)
- // 8, keyhash                ; bootstrap address
+ (  0, spending: keyhash,    deleg: keyhash    ; base address
+ // 1, spending: keyhash,    deleg: scripthash ; base address
+ // 2, spending: scripthash, deleg: keyhash    ; base address
+ // 3, spending: scripthash, deleg: scripthash ; base address
+ // 4, spending: keyhash,    deleg: pointer    ; pointer address
+ // 5, spending: scripthash, deleg: pointer    ; pointer address
+ // 6, spending: keyhash                       ; enterprise address (null staking reference)
+ // 7, spending: scripthash                    ; enterprise address (null staking reference)
+ // 8, spending: keyhash                       ; bootstrap address
  )
 
 transaction_input = [transaction_id : hash, index : uint]
@@ -62,7 +62,7 @@ script =
   [  0, keyhash
   // 1, [ * script ]
   // 2, [ * script ]
-  // 3, uint, [ * script ]
+  // 3, m: uint, [ * script ]
   ]
 
 credential =
@@ -70,7 +70,8 @@ credential =
   // 1, scripthash
   // 2, genesishash
   )
- withdrawals = { * [credential] => coin }
+
+withdrawals = { * [credential] => coin }
 
 unit_interval = rational
 
@@ -79,31 +80,31 @@ rational =  #6.30(
    , denominator : uint
    ])
 
-pool_params = ( #6.258([* keyhash]) ; pool owners
-              , coin                ; cost
-              , unit_interval       ; margin
-              , coin                ; pledge
-              , keyhash             ; operator
-              , vrf_keyhash        ; vrf keyhash
-              , [credential]        ; reward account
+pool_params = ( owners: #6.258([* keyhash])      ; pool owners
+              , cost:           coin             ; cost
+              , margin:         unit_interval    ; margin
+              , pledge:         coin             ; pledge
+              , operator:       keyhash          ; operator
+              , vrf_keyhash:    vrf_keyhash      ; vrf keyhash
+              , reward_account: [credential]     ; reward account
               )
 
 delegation_certificate =
-  [ 0, keyhash                       ; stake key registration
+  [ 0, keyhash                        ; stake key registration
   // 1, scripthash                    ; stake script registration
   // 2, keyhash                       ; stake key de-registration
   // 3, scripthash                    ; stake script de-registration
   // 4                                ; stake key delegation
-      , keyhash                       ; delegating key
-      , keyhash                       ; key delegated to
+      , deleg_from: keyhash           ; delegating key
+      , deleg_to:   keyhash           ; key delegated to
   // 5                                ; stake script delegation
-      , scripthash                    ; delegating script
-      , keyhash                       ; key delegated to
+      , deleg_from: scripthash        ; delegating script
+      , deleg_to:   keyhash           ; key delegated to
   // 6, keyhash, pool_params          ; stake pool registration
   // 7, keyhash, epoch                ; stake pool retirement
   // 8                                ; genesis key delegation
-      , genesishash                   ; delegating key
-      , keyhash                       ; key delegated to
+      , deleg_from: genesishash       ; delegating key
+      , deleg_to:   keyhash           ; key delegated to
   // 9, move_instantaneous_reward ; move instantaneous rewards
   ]
 


### PR DESCRIPTION
**Codegen cleanup:**

Generated code should be more readable now, as we try harder to generate useful field names.
We also no longer store field such as
```rust
pub struct Foo {
    group: groups::Foo,
}
```
to now be
```rust
pub struct Foo(groups::Foo);
```
and likewise for the binary data wrappers.

In the future we could remove the `groups` module and have everything as a part of the root structs. They were an abstraction that was thought would help earlier on, especially if plain groups were represented as both array/map. But now the code generation process is changed and the generation of the exposed wrapper + the inner group data is more coupled rather than being a separate process, so it makes less sense. This would make no difference for the wasm API, but for expanding upon the generated library from rust it would be you'd just do `self.x` instead of `self.0.x` or `self.0.x.0`, etc.

The subset of `shelley.cddl` we support also was renamed to provide more field names


**Optional field setters:**

Before we only generated a way to set mandatory fields as part of the constructor, but now optional ones generate setters (the ctor defaults them to `None`) to actually use them.