### PR TITLE
Type choice support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The `lib.rs` contains all wasm-exposable code that clients of the generated code
 All generated types contain a `new(...)` constructor as well as a `to_bytes()` function that serializes to a byte buffer as the CBOR structure.
 
 * Primitives - `bytes`, `bstr`, `tstr`, `text`, `uint`, `nint` (last two truncated to 32 bytes for now)
+* Fixed values - `null`, `nil`, `true`, `false`
 * Array values - `[uint]`
 * Inline groups at root level - `foo = ( a: uint, b: uint)`
 * Array groups - `foo = [uint, tstr, 0, bytes]`
@@ -23,6 +24,7 @@ All generated types contain a `new(...)` constructor as well as a `to_bytes()` f
 * Tagged major types - `rational =  #6.30([ numerator : uint, denominator : uint])`
 * Optional fields - `foo = { ? 0 : bytes }`
 * Type aliases - `foo = bar`
+* Type choices - `foo = uint / tstr`.
 
 It should be noted that for our purposes when we encounter a type that is an alias or transitiviely an alias for binary bytes, we always create a wrapper type for it, as in our use cases those should not be mixed and are crypto keys, hashes, and so on.
 
@@ -31,12 +33,17 @@ This lets us get around the `wasm_bindgen` limitation (without implementing cros
 
 Identifiers and fields are also changed to rust style. ie `foo_bar = { Field-Name: text }` gets converted into `struct FooBar { field_name: String }`
 
+Group choices are handled as an enum with each choice being a variant. This enum is then wrapped around a wasm-exposed struct as `wasm_bindgen` does not support rust enums with members/values.
+Group choices that are a single field use just that field as the enum variant, otherwise we create a `GroupN` enum with the fields of that group choice.
+
+Type choices are handled via enums as well with the name defaulting to `AOrBOrC` for `A / B / C` when inlined as a field/etc, and will take on the type identifier if provided ie `foo = A / B / C` would be `Foo`.
+Any field that is `T / null` is transformed as a special case into `Option<T>` rather than creating a `TOrNull` enum.
+
 ### Limitations
 
 * Primitive `int` not supported due to no type choice support (defined as `uint / nint`)
 * There is no support for deserialization as this is not of immediate use for us.
 * No accessor functions (easily added but we don't need them yet as the focus is constructing CBOR not deserializing)
-* No type choices - `foo = uint / tstr`. Only found in transaction metadata in `shelley.cddl`
 * Does not support optional group `[(...)]` or `{(...)}` syntax - must use `[...]` for `{...}` for groups
 * Ignores occurence specifiers: `*`, `+` or `n*m`
 * No support for sockets
@@ -44,6 +51,7 @@ Identifiers and fields are also changed to rust style. ie `foo_bar = { Field-Nam
 * No heterogenous arrays as fields - `foo: [uint]` is fine but `foo: [uint, tstr]` is not. Not found anywhere in `shelley.cddl`
 * CDDL generics not supported - just edit the cddl to inline it yourself for now
 * Keys in struct-type maps are limited to `uint` and text. Other types are not found anywhere in `shelley.cddl`.
+* Optional fixed-value fields not properly supported - `(? foo: 5)`
 
 
 `wasm_bindgen` also cannot expose doubly-nested types like `Vec<Vec<T>` which can be a limitation if `T` was a non-byte primtive.

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,8 +263,6 @@ impl GlobalScope {
     }
 
     fn mark_plain_group(&mut self, name: String, group: Group) {
-        // TODO: support for plain groups with choices
-        //assert_eq!(group.group_choices.len(), 1);
         self.plain_groups.insert(name, group);
     }
 
@@ -275,7 +273,10 @@ impl GlobalScope {
 
     fn plain_group_fields(&self, name: &str) -> Option<Vec<GroupEntry>> {
         match self.plain_groups.get(name) {
-            Some(group) => Some(group.group_choices.first().unwrap().group_entries.iter().map(|(e, _)| e.clone()).collect()),
+            Some(group) => {
+                assert_eq!(group.group_choices.len(), 1, "can only get fields of plain group without choices");
+                Some(group.group_choices.first().unwrap().group_entries.iter().map(|(e, _)| e.clone()).collect())
+            },
             None => None,
         }
     }
@@ -494,7 +495,7 @@ impl GlobalScope {
                 }
                 body.push_block(opt_block);
             },
-            RustType::Map(key_type, value_type) => {
+            RustType::Map(_key, _value) => {
                 // body.line("serializer.write_map(cbor_event::Len::Indefinite)?;");
                 // let mut table_loop = codegen::Block::new(&format!("for (key, value) in {}.iter()", expr));
                 // self.generate_serialize(&key_type, String::from("key"), &mut table_loop, false);

--- a/static/prelude.rs
+++ b/static/prelude.rs
@@ -2,12 +2,36 @@ use cbor_event::{self, de::{Deserialize, Deserializer}, se::{Serialize, Serializ
 use std::io::Write;
 use wasm_bindgen::prelude::*;
 
-// if we don't have anything else here anymore, we should probably just
-// generate this directly at the top of serialization.rs
-
+// we should probably just generate this directly at the top of serialization.rs
 pub trait SerializeEmbeddedGroup {
     fn serialize_as_embedded_group<'a, W: Write + Sized>(
         &self,
         serializer: &'a mut Serializer<W>,
     ) -> cbor_event::Result<&'a mut Serializer<W>>;
+}
+
+// CBOR has int = int / nint
+#[wasm_bindgen]
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Int(i128);
+
+#[wasm_bindgen]
+impl Int {
+    pub fn new(x: u64) -> Self {
+        Self(x as i128)
+    }
+
+    pub fn new_negative(x: u64) -> Self {
+        Self(-(x as i128))
+    }
+}
+
+impl cbor_event::se::Serialize for Int {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        if self.0 < 0 {
+            serializer.write_negative_integer((-self.0) as i64)
+        } else {
+            serializer.write_unsigned_integer(self.0 as u64)
+        }
+    }
 }


### PR DESCRIPTION
Only group choice support existed before, but not type choice, ie `foo = x  / y / z` or `foo = { bar: a / b, baz: c / d }`

Now type choices should work as well with some caveats:

* ~primitives in type choices cause issues with rust syntax~
* ~repeated types within a choice (ie with differences in occurrences/size
  limits/ets) cause issues (problem with `relays` used in new proposed shelley.cddl as IPV4/IPV6 are just binary bytes but with different sizes~
* ~Isues with byte strings inside type choices~
* ~Not directly related, but we don't support CDDL's null which is used
  in the motivating use-cases in shelley.cddl's proposed changes~
* ~Serialization is broke for non-rust-struct types~
* Inlined groups/arrays in type choices don't work in general case - homogeneous array/table types are supported though
* ~Unsure if tags in type choices work - needs investigations~ works
* ~Tagged type choices not supported~

The lack of heterogeneous arrays / general maps here is fine for now. What we have now is enough to support tx metadata