### PR TITLE
Respect deserialized format (e.g. order, en encodings)

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -5,3 +5,5 @@ pub const ANNOTATE_FIELDS: bool = true;
 pub const GENERATE_TO_FROM_BYTES: bool = true;
 pub const USE_EXTENDED_PRELUDE: bool = true;
 pub const BINARY_WRAPPERS: bool = true;
+// Preservs CBOR encoding upon deserialization e.g. definite vs indefinite, map ordering
+pub const PRESERVE_ENCODINGS: bool = true;

--- a/static/Cargo.toml
+++ b/static/Cargo.toml
@@ -9,3 +9,4 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 cbor_event = "2.1.3"
 wasm-bindgen = { version = "0.2", features=["serde-serialize"] }
+linked-hash-map = "0.5.3"


### PR DESCRIPTION
CBOR has several ways to vary in the bytes encoded from a single
semantically-equal piece of information:

1) Map ordering of keys
2) Integer encodings (1 vs 4 bytes) (includes length for major types)
3) Definite vs indefinite lengths of arrays/maps (and strings)

We implement 1 and 3 (excluding for strings) here as 2 would require
changes to `cbor_event` and for our purposes (Cardano blockchain) we've
never seen any data being posted that didn't use the smallest encoding
for integers/lengths.

This is controlled by a new flag in `cmd.rs`. If this is not something
an end-user cares about they should disable it as it creates extra
fields to remember this data as well as extra code. It also necessitates
an extra dependency for `linked_hash_map`.

Resolves #11

This PR might get updated with tests tomorrow/soon.