### PR TITLE
Canonical form toggling

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,8 +2,10 @@
 // TODO: make non-annotation generate different DeserializeError that is simpler
 //       and works with From<cbor_event:Error> only
 pub const ANNOTATE_FIELDS: bool = true;
-pub const GENERATE_TO_FROM_BYTES: bool = true;
+// TODO: fix and/or allow both options (take to_from_bytes!() from csl)
+pub const GENERATE_TO_FROM_BYTES: bool = false;
 pub const USE_EXTENDED_PRELUDE: bool = true;
 pub const BINARY_WRAPPERS: bool = true;
 // Preservs CBOR encoding upon deserialization e.g. definite vs indefinite, map ordering
 pub const PRESERVE_ENCODINGS: bool = true;
+pub const CANONICAL_FORM: bool = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // since we don't need it to be dynamic so it's fine. codegen::Impl::new("a", "{z::b, z::c}")
         // does not work.
         gen_scope.scope().raw("// This library was code-generated using an experimental CDDL to rust tool:\n// https://github.com/Emurgo/cddl-codegen");
-        gen_scope.scope().raw("use cbor_event::{self, de::Deserializer, se::{Serialize, Serializer}};");
+        if cmd::PRESERVE_ENCODINGS && cmd::CANONICAL_FORM {
+            gen_scope.scope().raw("use cbor_event::{self, de::Deserializer, se::Serializer};");
+        } else {
+            gen_scope.scope().raw("use cbor_event::{self, de::Deserializer, se::{Serialize, Serializer}};");
+        }
         gen_scope.scope().import("std::io", "{BufRead, Seek, Write}");
         gen_scope.scope().import("wasm_bindgen::prelude", "*");
         gen_scope.scope().import("prelude", "*");
@@ -75,7 +79,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::write("export/src/lib.rs", gen_scope.scope().to_string()).unwrap();
     std::fs::write("export/src/serialization.rs", gen_scope.serialize_scope().to_string()).unwrap();
     std::fs::copy("static/Cargo.toml", "export/Cargo.toml").unwrap();
-    std::fs::copy("static/prelude.rs", "export/src/prelude.rs").unwrap();
+    if cmd::PRESERVE_ENCODINGS && cmd::CANONICAL_FORM {
+        std::fs::copy("static/prelude_canonical.rs", "export/src/prelude.rs").unwrap();
+    } else {
+        std::fs::copy("static/prelude.rs", "export/src/prelude.rs").unwrap();
+    }
 
     types.print_info();
 

--- a/static/prelude_canonical.rs
+++ b/static/prelude_canonical.rs
@@ -1,0 +1,273 @@
+use cbor_event::{self, de::Deserializer, se::Serializer};
+use std::io::{BufRead, Seek, Write};
+use wasm_bindgen::prelude::*;
+
+#[derive(Debug)]
+pub enum Key {
+    Str(String),
+    Uint(u64),
+}
+
+impl std::fmt::Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Key::Str(x) => write!(f, "\"{}\"", x),
+            Key::Uint(x) => write!(f, "{}", x),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum DeserializeFailure {
+    BreakInDefiniteLen,
+    CBOR(cbor_event::Error),
+    DefiniteLenMismatch(u64, Option<u64>),
+    DuplicateKey(Key),
+    EndingBreakMissing,
+    ExpectedNull,
+    FixedValueMismatch{
+        found: Key,
+        expected: Key,
+    },
+    MandatoryFieldMissing(Key),
+    NoVariantMatched,
+    RangeCheck{
+        found: usize,
+        min: Option<isize>,
+        max: Option<isize>,
+    },
+    TagMismatch{
+        found: u64,
+        expected: u64,
+    },
+    UnknownKey(Key),
+    UnexpectedKeyType(cbor_event::Type),
+}
+
+// we might want to add more info like which field,
+#[derive(Debug)]
+pub struct DeserializeError {
+    location: Option<String>,
+    failure: DeserializeFailure,
+}
+
+impl DeserializeError {
+    pub fn new<T: Into<String>>(location: T, failure: DeserializeFailure) -> Self {
+        Self {
+            location: Some(location.into()),
+            failure,
+        }
+    }
+
+    pub fn annotate<T: Into<String>>(self, location: T) -> Self {
+        match self.location {
+            Some(loc) => Self::new(format!("{}.{}", location.into(), loc), self.failure),
+            None => Self::new(location, self.failure),
+        }
+    }
+}
+
+impl std::fmt::Display for DeserializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.location {
+            Some(loc) => write!(f, "Deserialization failed in {} because: ", loc),
+            None => write!(f, "Deserialization: "),
+        }?;
+        match &self.failure {
+            DeserializeFailure::BreakInDefiniteLen => write!(f, "Encountered CBOR Break while reading definite length sequence"),
+            DeserializeFailure::CBOR(e) => e.fmt(f),
+            DeserializeFailure::DefiniteLenMismatch(found, expected) => {
+                write!(f, "Definite length mismatch: found {}", found)?;
+                if let Some(expected_elems) = expected {
+                    write!(f, ", expected: {}", expected_elems)?;
+                }
+                Ok(())
+            },
+            DeserializeFailure::DuplicateKey(key) => write!(f, "Duplicate key: {}", key),
+            DeserializeFailure::EndingBreakMissing => write!(f, "Missing ending CBOR Break"),
+            DeserializeFailure::ExpectedNull => write!(f, "Expected null, found other type"),
+            DeserializeFailure::FixedValueMismatch{ found, expected } => write!(f, "Expected fixed value {} found {}", expected, found),
+            DeserializeFailure::MandatoryFieldMissing(key) => write!(f, "Mandatory field {} not found", key),
+            DeserializeFailure::NoVariantMatched => write!(f, "No variant matched"),
+            DeserializeFailure::RangeCheck{ found, min, max } => match (min, max) {
+                (Some(min), Some(max)) => write!(f, "{} not in range {} - {}", found, min, max),
+                (Some(min), None) => write!(f, "{} not at least {}", found, min),
+                (None, Some(max)) => write!(f, "{} not at most {}", found, max),
+                (None, None) => write!(f, "invalid range (no min nor max specified)"),
+            },
+            DeserializeFailure::TagMismatch{ found, expected } => write!(f, "Expected tag {}, found {}", expected, found),
+            DeserializeFailure::UnknownKey(key) => write!(f, "Found unexpected key {}", key),
+            DeserializeFailure::UnexpectedKeyType(ty) => write!(f, "Found unexpected key of CBOR type {:?}", ty),
+        }
+    }
+}
+
+impl From<DeserializeFailure> for DeserializeError {
+    fn from(failure: DeserializeFailure) -> DeserializeError {
+        DeserializeError {
+            location: None,
+            failure,
+        }
+    }
+}
+
+impl From<cbor_event::Error> for DeserializeError {
+    fn from(err: cbor_event::Error) -> DeserializeError {
+        DeserializeError {
+            location: None,
+            failure: DeserializeFailure::CBOR(err),
+        }
+    }
+}
+
+pub trait Serialize {
+    fn serialize<'a, W: Write + Sized>(
+        &self,
+        serializer: &'a mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'a mut Serializer<W>>;
+}
+
+impl<T: cbor_event::se::Serialize> Serialize for T {
+    fn serialize<'a, W: Write + Sized>(
+        &self,
+        serializer: &'a mut Serializer<W>,
+        _force_canonical: bool,
+    ) -> cbor_event::Result<&'a mut Serializer<W>> {
+        <T as cbor_event::se::Serialize>::serialize(self, serializer)
+    }
+}
+
+// we should probably just generate this directly at the top of serialization.rs
+pub trait SerializeEmbeddedGroup {
+    fn serialize_as_embedded_group<'a, W: Write + Sized>(
+        &self,
+        serializer: &'a mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'a mut Serializer<W>>;
+}
+
+// same as cbor_event::de::Deserialize but with our DeserializeError
+pub trait Deserialize {
+    fn deserialize<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+    ) -> Result<Self, DeserializeError> where Self: Sized;
+}
+
+impl<T: cbor_event::de::Deserialize> Deserialize for T {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<T, DeserializeError> {
+        T::deserialize(raw).map_err(|e| DeserializeError::from(e))
+    }
+}
+
+pub trait DeserializeEmbeddedGroup {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+        read_len: &mut CBORReadLen,
+        len: cbor_event::Len,
+    ) -> Result<Self, DeserializeError> where Self: Sized;
+}
+
+pub trait ToBytes {
+    fn to_bytes(&self, force_canonical: bool) -> Vec<u8>;
+}
+
+impl<T: Serialize> ToBytes for T {
+    fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        let mut buf = Serializer::new_vec();
+        self.serialize(&mut buf, force_canonical).unwrap();
+        buf.finalize()
+    }
+}
+
+pub trait FromBytes {
+    fn from_bytes(data: Vec<u8>) -> Result<Self, JsValue> where Self: Sized;
+}
+
+impl<T: Deserialize + Sized> FromBytes for T {
+    fn from_bytes(data: Vec<u8>) -> Result<Self, JsValue> {
+        let mut raw = Deserializer::from(std::io::Cursor::new(data));
+        Self::deserialize(&mut raw).map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+}
+
+// CBOR has int = int / nint
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Int(i128);
+
+#[wasm_bindgen]
+impl Int {
+    pub fn new(x: u64) -> Self {
+        Self(x as i128)
+    }
+
+    pub fn new_negative(x: u64) -> Self {
+        Self(-(x as i128))
+    }
+}
+
+impl cbor_event::se::Serialize for Int {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        if self.0 < 0 {
+            serializer.write_negative_integer((-self.0) as i64)
+        } else {
+            serializer.write_unsigned_integer(self.0 as u64)
+        }
+    }
+}
+
+impl Deserialize for Int {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            match raw.cbor_type()? {
+                cbor_event::Type::UnsignedInteger => Ok(Self(raw.unsigned_integer()? as i128)),
+                cbor_event::Type::NegativeInteger => Ok(Self(-raw.negative_integer()? as i128)),
+                _ => Err(DeserializeFailure::NoVariantMatched.into()),
+            }
+        })().map_err(|e| e.annotate("Int"))
+    }
+}
+
+pub struct CBORReadLen {
+    deser_len: cbor_event::Len,
+    read: u64,
+}
+
+impl CBORReadLen {
+    pub fn new(len: cbor_event::Len) -> Self {
+        Self {
+            deser_len: len,
+            read: 0,
+        }
+    }
+
+    // Marks {n} values as being read, and if we go past the available definite length
+    // given by the CBOR, we return an error.
+    pub fn read_elems(&mut self, count: usize) -> Result<(), DeserializeFailure> {
+        match self.deser_len {
+            cbor_event::Len::Len(n) => {
+                self.read += count as u64;
+                if self.read > n {
+                    Err(DeserializeFailure::DefiniteLenMismatch(n, None))
+                } else {
+                    Ok(())
+                }
+            },
+            cbor_event::Len::Indefinite => Ok(()),
+        }
+    }
+
+    pub fn finish(&self) -> Result<(), DeserializeFailure> {
+        match self.deser_len {
+            cbor_event::Len::Len(n) => {
+                if self.read == n {
+                    Ok(())
+                } else {
+                    Err(DeserializeFailure::DefiniteLenMismatch(n, Some(self.read)))
+                }
+            },
+            cbor_event::Len::Indefinite => Ok(()),
+        }
+    }
+}


### PR DESCRIPTION
Now that #28 allows for preserving of deserialization order, there must
be a way to force canonical serialization instead of just defaulting to
it. When PRESERVE_ENCODINGS and CANONICAL_FORM are true the
serialization traits contain a force_canonical parameter which can
override the deserialized format.