### PR TITLE
Add support for .cbor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tests/*/export/**
 target/**
+out/*

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -186,8 +186,15 @@ impl<'a> IntermediateTypes<'a> {
                     unimplemented!("what to do here?");
                 }
             },
-            RustStructType::Wrapper { min_max: Some(_) , ..} => {
+            RustStructType::Wrapper { control: Some(ControlOperator::Range(_)) , ..} => {
                 self.mark_new_can_fail(rust_struct.ident.clone());
+            },
+            RustStructType::Wrapper { control: Some(ControlOperator::Control(_)) , ..} => {
+                self.mark_new_can_fail(rust_struct.ident.clone());
+                // match ctl {
+                //     RustType::Rust(ident) => self.mark_new_can_fail(ident.clone()),
+                //     _ => todo!(".cbor currently only supported for identifiers")
+                // }
             },
             _ => (),
         }
@@ -1218,6 +1225,12 @@ pub struct RustStruct {
 }
 
 #[derive(Clone, Debug)]
+pub enum ControlOperator {
+    Range((Option<isize>, Option<isize>)),
+    Control(RustType),
+}
+
+#[derive(Clone, Debug)]
 pub enum RustStructType {
     Record(RustRecord),
     Table {
@@ -1236,7 +1249,7 @@ pub enum RustStructType {
     },
     Wrapper{
         wrapped: RustType,
-        min_max: Option<(Option<isize>, Option<isize>)>,
+        control: Option<ControlOperator>,
     }
 }
 
@@ -1291,13 +1304,13 @@ impl RustStruct {
         }
     }
 
-    pub fn new_wrapper(ident: RustIdent, tag: Option<usize>, wrapped_type: RustType, min_max: Option<(Option<isize>, Option<isize>)>) -> Self {
+    pub fn new_wrapper(ident: RustIdent, tag: Option<usize>, wrapped_type: RustType, control: Option<ControlOperator>) -> Self {
         Self {
             ident,
             tag,
             variant: RustStructType::Wrapper {
                 wrapped: wrapped_type,
-                min_max
+                control
             },
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -95,3 +95,8 @@ fn canonical() {
 fn rust_wasm_split() {
     run_test("rust-wasm-split", &[]);
 }
+
+#[test]
+fn cbor_in_cbor() {
+    run_test("cbor-in-cbor", &[]);
+}

--- a/tests/cbor-in-cbor/test.cddl
+++ b/tests/cbor-in-cbor/test.cddl
@@ -1,0 +1,2 @@
+bar = bytes
+foo = bytes .cbor bar

--- a/tests/cbor-in-cbor/test.cddl
+++ b/tests/cbor-in-cbor/test.cddl
@@ -1,2 +1,7 @@
 bar = bytes
 foo = bytes .cbor bar
+
+baz = {
+      0 : bytes .cbor bar
+    ? 2 : bytes .cbor bar
+}


### PR DESCRIPTION
This PR adds support for #41 using option 1 for the implementation

Here is the generated code from the test

```rust

type Bar = Vec<u8>;

#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
pub struct Foo(Bar);

impl Foo {
    pub fn get(&self) -> &Bar {
        &self.0
    }

    pub fn new(inner: Bar) -> Self {
        Self(inner)
    }
}

impl From<Bar> for Foo {
    fn from(inner: Bar) -> Self {
        Foo::new(inner)
    }
}

impl From<Foo> for Bar {
    fn from(wrapper: Foo) -> Self {
        wrapper.0
    }
}

impl cbor_event::se::Serialize for Foo {
    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
        let mut inner_se = Serializer::new_vec();
        inner_se.write_bytes(&self.0)?;
        serializer.write_bytes(&inner_se.finalize())
    }
}

impl Deserialize for Foo {
    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
        let mut inner_de = &mut Deserializer::from(std::io::Cursor::new(raw.bytes()?));
        Ok(Self(inner_de.bytes()?))
    }
}
```

TODO:
- [ ] wait until upstream  `cbor-preserver-everything` is merged
- [ ] write tests (not too sure how to do this yet)
- [ ] support maps with .cbor fields
- [ ] give up on enums? (or fix `TODO: do we need to handle aliases here?`)
- [ ] Use `serialize_cbor_in_cbor` to simplify code?