### PR TITLE
Move encoding fields into its own structs + enum rework

### DIFF
--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -8,6 +8,7 @@ use crate::generation::table_type;
 use crate::utils::{
     cddl_prelude,
     convert_to_camel_case,
+    convert_to_snake_case,
     is_identifier_reserved,
     is_identifier_user_defined,
 };
@@ -1209,6 +1210,17 @@ impl EnumVariant {
             rust_type,
             serialize_as_embedded_group,
         }
+    }
+
+    pub fn name_as_var(&self) -> String {
+        let snake = convert_to_snake_case(&self.name.to_string());
+        // we can't use (rust) reserved keywords as param: eg new_u32(u32: u32)
+        // TODO: do we need to cover any other (rust) reserved keywords?
+        String::from(match snake.as_str() {
+            "u8" | "u16" | "u32" | "u64" => "uint",
+            "i8" | "i16" | "i32" | "i64" => "int",
+            x => x,
+        })
     }
 }
 


### PR DESCRIPTION
Structs now contain all their encoding fields in encoding structs e.g.
struct `Foo` contains a `encodings: Option<FooEncoding>` which contains
all the encoding fields rather than directly in `Foo`. This should make
things a lot clearer. The encoding structs are contained within
`src/cbor_encodings.rs`.

Enums (type/group choices) were also refactored wrt encoding variables.
Enum variants with more than one field are now named structs e.g.
```
Bar{
   bar: Bar,
   bar_encoding_1: ...,
   bar_encoding_2: ...,
}
```
to help with pattern matching so you can do `Bar{ bar, .. } =>`.

Enums with a single field remain as tuples e.g. `Bar(Bar)`.