### PR TITLE
Add u8, i8, u16, i16 to prelude

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -363,6 +363,8 @@ impl GenerationScope {
                 Primitive::Str => {
                     write_string_sz(body, "write_text", serializer_use, &config.expr, line_ender, &encoding_var);
                 },
+                Primitive::I8 |
+                Primitive::I16 |
                 Primitive::I32 |
                 Primitive::I64 => {
                     let mut pos = Block::new(&format!("if {} >= 0", expr_deref));
@@ -372,7 +374,7 @@ impl GenerationScope {
                     write_using_sz(&mut neg, "write_negative_integer", serializer_use, &format!("{} as i128", expr_deref), line_ender, &encoding_var_deref);
                     body.push_block(neg);
                 },
-                Primitive::U32 => {
+                Primitive::U8 | Primitive::U16 | Primitive::U32 => {
                     write_using_sz(body, "write_unsigned_integer", serializer_use, &format!("{} as u64", expr_deref), line_ender, &encoding_var_deref);
                 },
                 Primitive::U64 => {
@@ -648,8 +650,10 @@ impl GenerationScope {
                 };
                 match p {
                     Primitive::Bytes => deser_primitive(final_exprs, "bytes", "bytes", "bytes"),
-                    Primitive::U32 => deser_primitive(final_exprs, "unsigned_integer", "x", &format!("x as {}", p.to_string())),
+                    Primitive::U8  | Primitive::U16 | Primitive::U32 => deser_primitive(final_exprs, "unsigned_integer", "x", &format!("x as {}", p.to_string())),
                     Primitive::U64 => deser_primitive(final_exprs, "unsigned_integer", "x", "x"),
+                    Primitive::I8 |
+                    Primitive::I16 |
                     Primitive::I32 |
                     Primitive::I64 => {
                         let mut sign = Block::new(&format!("{}match {}.unsigned_integer{}()", before, deserializer_name, sz_str));
@@ -917,6 +921,8 @@ impl GenerationScope {
                     }
                     let mut dup_check = Block::new(&format!("if {}.insert({}.clone(), {}).is_some()", table_var, key_var_name, value_var_name));
                     let dup_key_error_key = match &**key_type {
+                        RustType::Primitive(Primitive::U8) |
+                        RustType::Primitive(Primitive::U16) |
                         RustType::Primitive(Primitive::U32) |
                         RustType::Primitive(Primitive::U64) => format!("Key::Uint({}.into())", key_var_name),
                         RustType::Primitive(Primitive::Str) => format!("Key::Str({})", key_var_name),
@@ -1909,9 +1915,13 @@ fn encoding_fields(name: &str, ty: &RustType) -> Vec<EncodingField> {
                     inner: Vec::new(),
                 }
             ],
+            Primitive::I8 |
+            Primitive::I16 |
             Primitive::I32 |
             Primitive::I64 |
             Primitive::N64 |
+            Primitive::U8 |
+            Primitive::U16 |
             Primitive::U32 |
             Primitive::U64 => vec![
                 EncodingField {
@@ -3292,8 +3302,12 @@ fn generate_wrapper_struct(gen_scope: &mut GenerationScope, types: &Intermediate
                 Primitive::Bytes |
                 Primitive::Str => "inner.len()",
                 Primitive::Bool |
+                Primitive::U8 |
+                Primitive::U16 |
                 Primitive::U32 |
                 Primitive::U64 |
+                Primitive::I8 |
+                Primitive::I16 |
                 Primitive::I32 |
                 Primitive::I64 |
                 Primitive::N64 => "inner",
@@ -3309,8 +3323,12 @@ fn generate_wrapper_struct(gen_scope: &mut GenerationScope, types: &Intermediate
                         Primitive::Bytes |
                         Primitive::Str => true,
                         Primitive::Bool |
+                        Primitive::U8 |
+                        Primitive::U16 |
                         Primitive::U32 |
                         Primitive::U64 => true,
+                        Primitive::I8 |
+                        Primitive::I16 |
                         Primitive::I32 |
                         Primitive::I64 |
                         Primitive::N64 => false,

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -68,6 +68,10 @@ impl<'a> IntermediateTypes<'a> {
         insert_alias("nint", RustType::Primitive(Primitive::N64));
         if CLI_ARGS.extended_prelude {
             // We also provide non-standard 32-bit variants for ease of use from wasm
+            insert_alias("u8", RustType::Primitive(Primitive::U8));
+            insert_alias("i8", RustType::Primitive(Primitive::I8));
+            insert_alias("u16", RustType::Primitive(Primitive::U16));
+            insert_alias("i16", RustType::Primitive(Primitive::I16));
             insert_alias("u32", RustType::Primitive(Primitive::U32));
             insert_alias("i32", RustType::Primitive(Primitive::I32));
             insert_alias("u64", RustType::Primitive(Primitive::U64));
@@ -417,6 +421,14 @@ impl FixedValue {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Primitive {
     Bool,
+    // u8 in our cddl
+    U8,
+    // i8 in our cddl
+    I8,
+    // u16 in our cddl
+    U16,
+    // i16 in our cddl
+    I16,
     // u32 in our cddl
     U32,
     // i32 in our cddl
@@ -436,6 +448,10 @@ impl Primitive {
     pub fn to_string(&self) -> String {
         String::from(match self {
             Primitive::Bool => "bool",
+            Primitive::U8 => "u8",
+            Primitive::I8 => "i8",
+            Primitive::U16 => "u16",
+            Primitive::I16 => "i16",
             Primitive::U32 => "u32",
             Primitive::I32 => "i32",
             Primitive::U64 => "u64",
@@ -450,6 +466,10 @@ impl Primitive {
     pub fn to_variant(&self) -> VariantIdent {
         VariantIdent::new_custom(match self {
             Primitive::Bool => "Bool",
+            Primitive::U8 => "U8",
+            Primitive::I8 => "I8",
+            Primitive::U16 => "U16",
+            Primitive::I16 => "I16",
             Primitive::U32 => "U32",
             Primitive::I32 => "I32",
             Primitive::U64 => "U64",
@@ -463,6 +483,10 @@ impl Primitive {
     pub fn cbor_types(&self) -> Vec<CBORType> {
         match self {
             Primitive::Bool => vec![CBORType::Special],
+            Primitive::U8 => vec![CBORType::UnsignedInteger],
+            Primitive::I8 => vec![CBORType::UnsignedInteger, CBORType::NegativeInteger],
+            Primitive::U16 => vec![CBORType::UnsignedInteger],
+            Primitive::I16 => vec![CBORType::UnsignedInteger, CBORType::NegativeInteger],
             Primitive::U32 => vec![CBORType::UnsignedInteger],
             Primitive::I32 => vec![CBORType::UnsignedInteger, CBORType::NegativeInteger],
             Primitive::U64 => vec![CBORType::UnsignedInteger],
@@ -658,6 +682,10 @@ impl RustType {
                     RustType::Primitive(p) => match p {
                         // converts to js number which is supported as Vec<T>
                         Primitive::Bool |
+                        Primitive::I8 |
+                        Primitive::U8 |
+                        Primitive::I16 |
+                        Primitive::U16 |
                         Primitive::I32 |
                         Primitive::U32 => true,
                         // since we generate these as BigNum/Int wrappers we can't nest them
@@ -957,9 +985,13 @@ impl RustType {
             RustType::Fixed(_f) => unreachable!(),
             RustType::Primitive(p) => match p {
                 Primitive::Bool |
+                Primitive::I8 |
+                Primitive::I16 |
                 Primitive::I32 |
                 Primitive::I64 |
                 Primitive::N64 |
+                Primitive::U8 |
+                Primitive::U16 |
                 Primitive::U32 |
                 Primitive::U64 => true,
                 Primitive::Str |

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -152,6 +152,10 @@ pub fn is_identifier_reserved(name: &str) -> bool {
 // as we also support our own identifiers for selecting integer precision, we need this too
 pub fn is_identifier_in_our_prelude(name: &str) -> bool {
     match name {
+        "u8" |
+        "i8" |
+        "u16" |
+        "i16" |
         "u32" |
         "i32" |
         "u64" |


### PR DESCRIPTION
We may want to consider f32, f64 (not sure about floating point spec in CBOR vs floating point implementation in Rust) and u128 and i128 (not sure about cbor support for these types) in the future