### PR TITLE
Allow giving group choice DSL names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ checksum = "52b3d8b289b6c7d6d8832c8e2bf151c7677126afa627f51e19a6320aec8237cb"
 [[package]]
 name = "cddl"
 version = "0.9.0"
-source = "git+https://github.com/dcSpark/cddl?branch=fix-comment-ast-parsing#922c9ce4f30b32e7049fff7e1acee52bc0bfa319"
+source = "git+https://github.com/dcSpark/cddl?branch=fix-group-comments#f85a35eeca552e40c263d1353d5891cb7e7d9d43"
 dependencies = [
  "abnf_to_pest",
  "base16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 cbor_event = "2.1.3"
-cddl = { git = 'https://github.com/dcSpark/cddl', branch = 'fix-comment-ast-parsing' }
+cddl = { git = 'https://github.com/dcSpark/cddl', branch = 'fix-group-comments' }
 clap = { version = "~3.1.5", features = ["derive"] }
 codegen = "0.1.3"
 either = "1.5.3"

--- a/src/comment_ast.rs
+++ b/src/comment_ast.rs
@@ -28,6 +28,16 @@ fn rule_metadata(input: &str) -> IResult<&str, RuleMetadata> {
   Ok((input, RuleMetadata { name: Some(name.to_string()) }))
 }
 
+
+impl <'a> From<Option<&'a cddl::ast::Comments<'a>>> for RuleMetadata {
+  fn from(comments: Option<&'a cddl::ast::Comments<'a>>) -> RuleMetadata {
+    match comments {
+      None => RuleMetadata::default(),
+      Some(c) => metadata_from_comments(&c.0)
+    }
+  }
+}
+
 pub fn metadata_from_comments(comments: &[&str]) -> RuleMetadata {
     let mut result = RuleMetadata::default();
     for comment in comments {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -846,8 +846,10 @@ pub fn parse_group(types: &mut IntermediateTypes, group: &Group, name: &RustIden
                 //     EnumVariant::new(variant_name.clone(), RustType::Rust(variant_name), true)
                 // },
             } else {
+                let rule_metadata = RuleMetadata::from(group_choice.comments_before_grpchoice.as_ref());
+                let ident_name = rule_metadata.name.unwrap_or_else(|| format!("{}{}", name, i));
                 // General case, GroupN type identifiers and generate group choice since it's inlined here
-                let variant_name = RustIdent::new(CDDLIdent::new(format!("{}{}", name, i)));
+                let variant_name = RustIdent::new(CDDLIdent::new(ident_name));
                 types.mark_plain_group(variant_name.clone(), None);
                 parse_group_choice(types, group_choice, &variant_name, rep, None, generic_params.clone());
                 EnumVariant::new(VariantIdent::new_rust(variant_name.clone()), RustType::Rust(variant_name), true)

--- a/tests/comment-dsl/input.cddl
+++ b/tests/comment-dsl/input.cddl
@@ -7,3 +7,11 @@ protocol_param_update = {
     0:  uint               ; @name minfee_a
   , 1:  uint               ; @name minfee_b
 }
+
+block = [
+    ; @name ebb_block_wrapper
+    0, bytes ; @name ebb_block_cbor
+    //
+    ; @name main_block_wrapper
+    1, bytes ; @name main_block_cbor
+]

--- a/tests/comment-dsl/tests.rs
+++ b/tests/comment-dsl/tests.rs
@@ -27,4 +27,12 @@ mod tests {
         assert_eq!(minfee_a, addr.minfee_a);
         assert_eq!(minfee_b, addr.minfee_b);
     }
+
+    #[test]
+    fn group_choice() {
+        // just checking these fields exist with the expected name
+        Block::new_ebb_block_wrapper(vec![]);
+        Block::new_main_block_wrapper(vec![]);
+        assert!(true);
+    }
 }


### PR DESCRIPTION
This PR allows giving names to group choices. It also fixes an upstream bug in the cddl lib related to AST parsing of group choice comments