### PR TITLE
@newtype custom getters

### DIFF
--- a/docs/docs/comment_dsl.mdx
+++ b/docs/docs/comment_dsl.mdx
@@ -53,6 +53,16 @@ script = [
 
 With code like `foo = uint` this creates an alias e.g. `pub type Foo = u64;` in rust. When we use `foo = uint ; @newtype` it instead creates a `pub struct Foo(u64);`.
 
+`@newtype` can also optionally specify a getter function e.g. `foo = uint ; @newtype custom_getter` will generate:
+
+```rust
+impl Foo {
+    pub fn custom_getter(&self) -> u64 {
+        self.0
+    }
+}
+```
+
 ## @no_alias
 
 ```cddl

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -2308,6 +2308,7 @@ pub struct RustStructConfig {
     pub custom_serialize: Option<String>,
     pub custom_deserialize: Option<String>,
     pub doc: Option<String>,
+    pub newtype_getter: Option<Option<String>>,
 }
 
 impl From<Option<&RuleMetadata>> for RustStructConfig {
@@ -2318,6 +2319,7 @@ impl From<Option<&RuleMetadata>> for RustStructConfig {
                 custom_serialize: rule_metadata.custom_serialize.clone(),
                 custom_deserialize: rule_metadata.custom_deserialize.clone(),
                 doc: rule_metadata.comment.clone(),
+                newtype_getter: rule_metadata.newtype.clone(),
             },
             None => Self::default(),
         }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -517,7 +517,9 @@ fn parse_type(
                                     min_max.1,
                                     ident_to_primitive(&cddl_ident).unwrap(),
                                 );
-                                if ranged_type.config.bounds.is_some() || rule_metadata.is_newtype {
+                                if ranged_type.config.bounds.is_some()
+                                    || rule_metadata.newtype.is_some()
+                                {
                                     // without bounds since passed in other param
                                     ranged_type.config.bounds = None;
                                     // has non-rust-primitive matching bounds
@@ -603,7 +605,7 @@ fn parse_type(
                                         ))
                                     }
                                     None => {
-                                        if rule_metadata.is_newtype {
+                                        if rule_metadata.newtype.is_some() {
                                             types.register_rust_struct(
                                                 parent_visitor,
                                                 RustStruct::new_wrapper(
@@ -1469,7 +1471,7 @@ fn parse_group_choice(
     };
     let rust_struct = match parse_group_type(types, parent_visitor, group_choice, rep, cli) {
         GroupParsingType::HomogenousArray(element_type) => {
-            if rule_metadata.is_newtype {
+            if rule_metadata.newtype.is_some() {
                 // generate newtype over array
                 RustStruct::new_wrapper(
                     name.clone(),
@@ -1484,7 +1486,7 @@ fn parse_group_choice(
             }
         }
         GroupParsingType::HomogenousMap(key_type, value_type) => {
-            if rule_metadata.is_newtype {
+            if rule_metadata.newtype.is_some() {
                 // generate newtype over map
                 RustStruct::new_wrapper(
                     name.clone(),
@@ -1506,7 +1508,7 @@ fn parse_group_choice(
         }
         GroupParsingType::Heterogenous | GroupParsingType::WrappedBasicGroup(_) => {
             assert!(
-                !rule_metadata.is_newtype,
+                rule_metadata.newtype.is_none(),
                 "Can only use @newtype on primtives + heterogenious arrays/maps"
             );
             // Heterogenous map or array with defined key/value pairs in the cddl like a struct
@@ -1551,7 +1553,7 @@ pub fn parse_group(
         if generic_params.is_some() {
             todo!("{}: generic group choices not supported", name);
         }
-        assert!(!parent_rule_metadata.is_newtype);
+        assert!(parent_rule_metadata.newtype.is_none());
         // Generate Enum object that is not exposed to wasm, since wasm can't expose
         // fully featured rust enums via wasm_bindgen
 

--- a/tests/comment-dsl/input.cddl
+++ b/tests/comment-dsl/input.cddl
@@ -21,7 +21,7 @@ typechoice =
     /
     [1, bytes] ; @name case_2
 
-protocol_magic = uint ; @newtype
+protocol_magic = uint ; @newtype get
 
 typechoice_variants =
     text      ; @name case_1

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -187,6 +187,7 @@ top_level_single_elem = [uint]
 
 wrapper_table = { * uint => uint } ; @newtype
 wrapper_list = [ * uint ] ; @newtype
+wrapper_int = uint ; @newtype custom_getter
 
 overlapping_inlined = [
 	; @name one

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -576,6 +576,12 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_getter() {
+        let x = WrapperInt::new(128);
+        assert_eq!(128, x.custom_getter());
+    }
+
+    #[test]
     fn docs() {
         use std::str::FromStr;
         // reading the file is the only way to test for comments being generated


### PR DESCRIPTION
Now you can optionally specify a getter e.g. `foo = uint ; @newtype custom_getter`.

Previously `@newtype` would always generate one named `get()` but this isn't always very helpful. Now you can explicitly name it, and if it's empty, no getter will be made, in which case users can choose to expose it however they want in their own `utils.rs` files.